### PR TITLE
Fix: wrong metrics

### DIFF
--- a/abstraction/executable.go
+++ b/abstraction/executable.go
@@ -8,7 +8,8 @@ import (
 // Executable is an object that can be executed using a execute method and stopped using cancel method
 type Executable interface {
 	Execute(context.Context) error
-	SetDoneHooks([]Executable)
-	SetFailHooks([]Executable)
+	SetMetaName(string)
+	SetDoneHooks(context.Context, []Executable)
+	SetFailHooks(context.Context, []Executable)
 	Cancel()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 
@@ -29,7 +28,6 @@ With its seamless integration and easy-to-use YAML configuration,
 Cronjob-go simplifies the process of scheduling and managing recurring tasks
 within your containerized applications.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(cmd.Args)
 		initConfig()
 	},
 }

--- a/config/compiler/task.go
+++ b/config/compiler/task.go
@@ -1,6 +1,8 @@
 package cfgcompiler
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/FMotalleb/crontab-go/abstraction"
@@ -8,7 +10,7 @@ import (
 	"github.com/FMotalleb/crontab-go/core/task"
 )
 
-func CompileTask(t *config.Task, logger *logrus.Entry) abstraction.Executable {
+func CompileTask(ctx context.Context, t *config.Task, logger *logrus.Entry) abstraction.Executable {
 	var exe abstraction.Executable
 	switch {
 	case t.Command != "":
@@ -26,14 +28,14 @@ func CompileTask(t *config.Task, logger *logrus.Entry) abstraction.Executable {
 
 	onDone := []abstraction.Executable{}
 	for _, d := range t.OnDone {
-		onDone = append(onDone, CompileTask(&d, logger))
+		onDone = append(onDone, CompileTask(ctx, &d, logger))
 	}
-	exe.SetDoneHooks(onDone)
+	exe.SetDoneHooks(ctx, onDone)
 	onFail := []abstraction.Executable{}
 	for _, d := range t.OnFail {
-		onFail = append(onFail, CompileTask(&d, logger))
+		onFail = append(onFail, CompileTask(ctx, &d, logger))
 	}
-	exe.SetFailHooks(onFail)
+	exe.SetFailHooks(ctx, onFail)
 
 	return exe
 }

--- a/config/compiler/task_test.go
+++ b/config/compiler/task_test.go
@@ -1,6 +1,7 @@
 package cfgcompiler_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -8,52 +9,63 @@ import (
 
 	"github.com/FMotalleb/crontab-go/config"
 	cfgcompiler "github.com/FMotalleb/crontab-go/config/compiler"
+	"github.com/FMotalleb/crontab-go/ctxutils"
 	mocklogger "github.com/FMotalleb/crontab-go/logger/mock_logger"
 )
 
 func TestCompileTask_NonExistingTask(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	logger, _ := mocklogger.HijackOutput(logrus.New())
 	log := logrus.NewEntry(logger)
 	taskConfig := &config.Task{}
 	assert.Panics(
 		t,
 		func() {
-			cfgcompiler.CompileTask(taskConfig, log)
+			cfgcompiler.CompileTask(ctx, taskConfig, log)
 		},
 	)
 }
 
 func TestCompileTask_GetTask(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	logger, _ := mocklogger.HijackOutput(logrus.New())
 	log := logrus.NewEntry(logger)
 	taskConfig := &config.Task{
 		Get: "test",
 	}
-	exe := cfgcompiler.CompileTask(taskConfig, log)
+	exe := cfgcompiler.CompileTask(ctx, taskConfig, log)
 	assert.NotEqual(t, exe, nil)
 }
 
 func TestCompileTask_CommandTask(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	logger, _ := mocklogger.HijackOutput(logrus.New())
 	log := logrus.NewEntry(logger)
 	taskConfig := &config.Task{
 		Command: "test",
 	}
-	exe := cfgcompiler.CompileTask(taskConfig, log)
+	exe := cfgcompiler.CompileTask(ctx, taskConfig, log)
 	assert.NotEqual(t, exe, nil)
 }
 
 func TestCompileTask_PostTask(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	logger, _ := mocklogger.HijackOutput(logrus.New())
 	log := logrus.NewEntry(logger)
 	taskConfig := &config.Task{
 		Post: "test",
 	}
-	exe := cfgcompiler.CompileTask(taskConfig, log)
+	exe := cfgcompiler.CompileTask(ctx, taskConfig, log)
 	assert.NotEqual(t, exe, nil)
 }
 
 func TestCompileTask_WithHooks(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	logger, _ := mocklogger.HijackOutput(logrus.New())
 	log := logrus.NewEntry(logger)
 	taskConfig := &config.Task{
@@ -69,6 +81,6 @@ func TestCompileTask_WithHooks(t *testing.T) {
 			},
 		},
 	}
-	exe := cfgcompiler.CompileTask(taskConfig, log)
+	exe := cfgcompiler.CompileTask(ctx, taskConfig, log)
 	assert.NotEqual(t, exe, nil)
 }

--- a/core/common/hooked.go
+++ b/core/common/hooked.go
@@ -9,6 +9,13 @@ import (
 	"github.com/FMotalleb/crontab-go/core/global"
 )
 
+const (
+	okMetricName  = "done_tasks"
+	okMetricHelp  = "Amount of done tasks (with ok status)"
+	errMetricName = "failed_tasks"
+	errMetricHelp = "Amount of failed tasks"
+)
+
 type Hooked struct {
 	metaName  string
 	doneHooks []abstraction.Executable
@@ -22,36 +29,28 @@ func (h *Hooked) SetMetaName(metaName string) {
 func (h *Hooked) SetDoneHooks(ctx context.Context, hooks []abstraction.Executable) {
 	global.CTX().MetricCounter(
 		ctx,
-		"done_tasks",
-		"Amount of done tasks (with ok status)",
-		prometheus.Labels{"task_type": h.metaName},
-	).Operate(
-		func(f float64) float64 {
-			return f + 1
-		},
-	)
+		okMetricName,
+		okMetricHelp,
+		prometheus.Labels{"task": h.metaName},
+	).Set(0)
 	h.doneHooks = hooks
 }
 
 func (h *Hooked) SetFailHooks(ctx context.Context, failHooks []abstraction.Executable) {
 	global.CTX().MetricCounter(
 		ctx,
-		"done_tasks",
-		"Amount of done tasks (with ok status)",
+		errMetricName,
+		errMetricHelp,
 		prometheus.Labels{"task_type": h.metaName},
-	).Operate(
-		func(f float64) float64 {
-			return f + 1
-		},
-	)
+	).Set(0)
 	h.failHooks = failHooks
 }
 
 func (h *Hooked) DoDoneHooks(ctx context.Context) []error {
 	global.CTX().MetricCounter(
 		ctx,
-		"failed_tasks",
-		"Amount of failed tasks",
+		okMetricName,
+		okMetricHelp,
 		prometheus.Labels{"task_type": h.metaName},
 	).Operate(
 		func(f float64) float64 {
@@ -64,8 +63,8 @@ func (h *Hooked) DoDoneHooks(ctx context.Context) []error {
 func (h *Hooked) DoFailHooks(ctx context.Context) []error {
 	global.CTX().MetricCounter(
 		ctx,
-		"failed_tasks",
-		"Amount of failed tasks",
+		errMetricName,
+		errMetricHelp,
 		prometheus.Labels{"task_type": h.metaName},
 	).Operate(
 		func(f float64) float64 {

--- a/core/common/hooked.go
+++ b/core/common/hooked.go
@@ -3,27 +3,75 @@ package common
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/FMotalleb/crontab-go/abstraction"
+	"github.com/FMotalleb/crontab-go/core/global"
 )
 
 type Hooked struct {
+	metaName  string
 	doneHooks []abstraction.Executable
 	failHooks []abstraction.Executable
 }
 
-func (h *Hooked) SetDoneHooks(hooks []abstraction.Executable) {
+func (h *Hooked) SetMetaName(metaName string) {
+	h.metaName = metaName
+}
+
+func (h *Hooked) SetDoneHooks(ctx context.Context, hooks []abstraction.Executable) {
+	global.CTX().MetricCounter(
+		ctx,
+		"done_tasks",
+		"Amount of done tasks (with ok status)",
+		prometheus.Labels{"task_type": h.metaName},
+	).Operate(
+		func(f float64) float64 {
+			return f + 1
+		},
+	)
 	h.doneHooks = hooks
 }
 
-func (h *Hooked) SetFailHooks(failHooks []abstraction.Executable) {
+func (h *Hooked) SetFailHooks(ctx context.Context, failHooks []abstraction.Executable) {
+	global.CTX().MetricCounter(
+		ctx,
+		"done_tasks",
+		"Amount of done tasks (with ok status)",
+		prometheus.Labels{"task_type": h.metaName},
+	).Operate(
+		func(f float64) float64 {
+			return f + 1
+		},
+	)
 	h.failHooks = failHooks
 }
 
 func (h *Hooked) DoDoneHooks(ctx context.Context) []error {
+	global.CTX().MetricCounter(
+		ctx,
+		"failed_tasks",
+		"Amount of failed tasks",
+		prometheus.Labels{"task_type": h.metaName},
+	).Operate(
+		func(f float64) float64 {
+			return f + 1
+		},
+	)
 	return executeTasks(ctx, h.doneHooks)
 }
 
 func (h *Hooked) DoFailHooks(ctx context.Context) []error {
+	global.CTX().MetricCounter(
+		ctx,
+		"failed_tasks",
+		"Amount of failed tasks",
+		prometheus.Labels{"task_type": h.metaName},
+	).Operate(
+		func(f float64) float64 {
+			return f + 1
+		},
+	)
 	return executeTasks(ctx, h.failHooks)
 }
 

--- a/core/common/hooked_test.go
+++ b/core/common/hooked_test.go
@@ -19,6 +19,12 @@ type mockExecutable struct {
 	err error
 }
 
+func newTask(typeName string) *mockExecutable {
+	m := new(mockExecutable)
+	m.Hooked.SetMetaName(typeName)
+	return m
+}
+
 func (m *mockExecutable) Execute(ctx context.Context) error {
 	return m.err
 }
@@ -36,32 +42,43 @@ func TestSetFailHooks(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	h := &Hooked{}
-	failHooks := []abstraction.Executable{&mockExecutable{}}
+	failHooks := []abstraction.Executable{newTask("test_fail_list")}
 	h.SetFailHooks(ctx, failHooks)
 	assert.Equal(t, failHooks, h.failHooks)
 }
 
 func TestDoDoneHooks_NoErrors(t *testing.T) {
-	h := &Hooked{
-		doneHooks: []abstraction.Executable{&mockExecutable{}},
-	}
-	errs := h.DoDoneHooks(context.Background())
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
+	tsk := newTask("parent_done_ok")
+	tsk.SetDoneHooks(ctx, []abstraction.Executable{newTask("test_done_ok")})
+
+	errs := tsk.DoDoneHooks(ctx)
 	assert.Zero(t, errs)
 }
 
 func TestDoFailHooks_WithErrors(t *testing.T) {
-	h := &Hooked{
-		failHooks: []abstraction.Executable{&mockExecutable{err: errors.New("fail")}},
-	}
-	errs := h.DoFailHooks(context.Background())
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
+	tsk := newTask("")
+	errHook := newTask("task_fail")
+	errHook.err = errors.New("fail")
+	tsk.SetFailHooks(ctx, []abstraction.Executable{errHook})
+
+	errs := tsk.DoFailHooks(ctx)
 	assert.Equal(t, len(errs), 1)
 	assert.EqualError(t, errs[0], "fail")
 }
 
 func TestExecuteTasks_MultipleErrors(t *testing.T) {
+	tsk1 := newTask("doFailList")
+	tsk1.err = errors.New("error1")
+
+	tsk2 := newTask("doFailList")
+	tsk2.err = errors.New("error2")
 	tasks := []abstraction.Executable{
-		&mockExecutable{err: errors.New("error1")},
-		&mockExecutable{err: errors.New("error2")},
+		tsk1,
+		tsk2,
 	}
 	errs := executeTasks(context.Background(), tasks)
 	assert.Equal(t, len(errs), 2)

--- a/core/common/hooked_test.go
+++ b/core/common/hooked_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/FMotalleb/crontab-go/abstraction"
+	"github.com/FMotalleb/crontab-go/ctxutils"
 )
 
 type mockExecutable struct {
@@ -23,16 +24,20 @@ func (m *mockExecutable) Execute(ctx context.Context) error {
 }
 
 func TestSetDoneHooks(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	h := &Hooked{}
 	hooks := []abstraction.Executable{}
-	h.SetDoneHooks(hooks)
+	h.SetDoneHooks(ctx, hooks)
 	assert.Equal(t, hooks, h.doneHooks)
 }
 
 func TestSetFailHooks(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxutils.JobKey, "test_job")
 	h := &Hooked{}
 	failHooks := []abstraction.Executable{&mockExecutable{}}
-	h.SetFailHooks(failHooks)
+	h.SetFailHooks(ctx, failHooks)
 	assert.Equal(t, failHooks, h.failHooks)
 }
 

--- a/core/concurrency/concurrent_pool.go
+++ b/core/concurrency/concurrent_pool.go
@@ -3,7 +3,6 @@ package concurrency
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 )
 
@@ -35,7 +34,6 @@ func NewConcurrentPool(capacity uint) (*ConcurrentPool, error) {
 func (p *ConcurrentPool) Lock() {
 	p.lockerLock.Lock()
 	defer p.lockerLock.Unlock()
-	fmt.Print(p.get())
 	if p.available > p.get() {
 		p.increase()
 		return

--- a/core/global/metrics.go
+++ b/core/global/metrics.go
@@ -41,7 +41,8 @@ func (c *GlobalContext) MetricCounter(
 				return 0.0
 			}
 			ans := item.Get()
-			item.Set(0)
+			// a counter should not reset after it's collected by Prometheus.
+			// item.Set(0)
 			return ans
 		},
 	)
@@ -53,7 +54,6 @@ func (c *GlobalContext) CountSignals(ctx context.Context, name string, signal <-
 	out := make(chan any)
 	go func() {
 		for c := range signal {
-			fmt.Print("1")
 			counter.Set(counter.Get() + 1)
 			out <- c
 		}

--- a/core/task/get.go
+++ b/core/task/get.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -100,5 +101,6 @@ func NewGet(task *config.Task, logger *logrus.Entry) abstraction.Executable {
 	get.SetMaxRetry(task.Retries)
 	get.SetRetryDelay(task.RetryDelay)
 	get.SetTimeout(task.Timeout)
+	get.SetMetaName(fmt.Sprintf("get: %s", task.Get))
 	return get
 }

--- a/core/task/post.go
+++ b/core/task/post.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -120,5 +121,6 @@ func NewPost(task *config.Task, logger *logrus.Entry) abstraction.Executable {
 	post.SetMaxRetry(task.Retries)
 	post.SetRetryDelay(task.RetryDelay)
 	post.SetTimeout(task.Timeout)
+	post.SetMetaName(fmt.Sprintf("post: %s", task.Post))
 	return post
 }


### PR DESCRIPTION
Fixes metrics issues:
Registers them as Done/Fail hook instead
Creates metrics when setting Done/Fail hooks
Is more descriptive
counters are real counters: to achieve the older results you need to use the rate methods of Prometheus