### PR TITLE
feat: cmd arg mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,11 @@ WEBSERVER_METRICS=true
 
 TZ=Asia/Tehran
 
+# defaults to sh on linux and cmd on windows
 SHELL=/bin/bash
+# can be an array (`:` seperated) the seperation can be escaped using `\:`
 SHELL_ARGS=-c
 
 # env value will enable the `CRONTAB_GO_EVENT_ARGUMENTS` environments variable and event data will be passed using this env
-# Can be [env, arg] any other value will not break the program but will prevent the event argument passing
-SHELL_ARG_COMPATIBILITY=env # arg
+# Can be [none (default), env, arg] any other value will not break the program but will be oprational as default value
+SHELL_ARG_COMPATIBILITY=none

--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,6 @@ LOG_FILE=/var/log/crontab-go.log
 LOG_STDOUT=true
 LOG_LEVEL=debug
 
-SHELL=/bin/bash
-SHELL_ARGS=-c
-
 WEBSERVER_ADDRESS=
 WEBSERVER_PORT=
 WEBSERVER_USERNAME=admin
@@ -14,3 +11,10 @@ WEBSERVER_PASSWORD=f2f9899c-567c-455f-8a82-77a2c66e736e
 WEBSERVER_METRICS=true
 
 TZ=Asia/Tehran
+
+SHELL=/bin/bash
+SHELL_ARGS=-c
+
+# env value will enable the `CRONTAB_GO_EVENT_ARGUMENTS` environments variable and event data will be passed using this env
+# Can be [env, arg] any other value will not break the program but will prevent the event argument passing
+SHELL_ARG_COMPATIBILITY=env # arg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,24 @@ jobs:
         run: make ci
       - name: Upload coverage
         uses: actions/upload-artifact@v4
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           name: coverage-${{ matrix.os }}
           path: coverage.*
 
       - run: goreleaser release --rm-dist --snapshot
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' && github.event_name != 'pull_request' }}
 
       - name: Upload dist
         uses: actions/upload-artifact@v4
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           name: dist-${{ matrix.os }}
           path: dist
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           fail_ci_if_error: true
           file: ./coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   funlen:
-    lines: 100
+    lines: 150
     statements: 50
   gocyclo:
     min-complexity: 15

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func Execute() {
 }
 
 func init() {
-	warnOnErr(godotenv.Load(), "Cannot initialize .env file: %s")
+	_ = godotenv.Load()
 
 	rootCmd.AddCommand(parser.ParserCmd)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is config.yaml)")
@@ -187,6 +187,12 @@ func setupEnv() {
 			"shell_args",
 		),
 		"Cannot bind shell_args env variable: %s",
+	)
+	warnOnErr(
+		viper.BindEnv(
+			"shell_arg_compatibility",
+		),
+		"Cannot bind shell_arg_compatibility env variable: %s",
 	)
 
 	viper.AutomaticEnv()

--- a/config.local.yaml
+++ b/config.local.yaml
@@ -3,7 +3,7 @@
 jobs:
   - name: echo
     tasks:
-      - command: echo "$0 $@"
+      - command: echo "$CRONTAB_GO_EVENT_ARGUMENTS"
         env:
           "COLE": test
     events:

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,8 @@ type TaskConnection struct {
 type ShellArgCompatibilityMode string
 
 const (
-	DefaultShellArgCompatibility ShellArgCompatibilityMode = ArgumentPassing
-	ArgumentPassing              ShellArgCompatibilityMode = "arg"
-	EnvironmentPassing           ShellArgCompatibilityMode = "env"
+	DefaultShellArgCompatibility ShellArgCompatibilityMode = EventArgOmit
+	EventArgOmit                 ShellArgCompatibilityMode = "none"
+	EventArgPassingAsArgs        ShellArgCompatibilityMode = "arg"
+	EventArgPassingAsEnviron     ShellArgCompatibilityMode = "env"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	WebServerPassword string `mapstructure:"webserver_password" json:"webserver_password,omitempty"`
 	WebServerMetrics  bool   `mapstructure:"webserver_metrics" json:"webserver_metrics,omitempty"`
 
+	ShellArgCompatibility ShellArgCompatibilityMode `mapstructure:"shell_arg_compatibility" json:"shell_arg_compatibility,omitempty"`
+
 	Jobs []*JobConfig `mapstructure:"jobs" json:"jobs"`
 }
 
@@ -109,3 +111,11 @@ type TaskConnection struct {
 	Volumes          []string `mapstructure:"volumes" json:"volumes,omitempty"`
 	Networks         []string `mapstructure:"networks" json:"networks,omitempty"`
 }
+
+type ShellArgCompatibilityMode string
+
+const (
+	DefaultShellArgCompatibility ShellArgCompatibilityMode = ArgumentPassing
+	ArgumentPassing              ShellArgCompatibilityMode = "arg"
+	EnvironmentPassing           ShellArgCompatibilityMode = "env"
+)

--- a/core/cmd_connection/cmd_utils/cmd_context.go
+++ b/core/cmd_connection/cmd_utils/cmd_context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/FMotalleb/crontab-go/config"
+	"github.com/FMotalleb/crontab-go/core/utils"
 	"github.com/FMotalleb/crontab-go/ctxutils"
 )
 
@@ -110,7 +111,7 @@ func (ctx *Ctx) getShellArgCompatibility() config.ShellArgCompatibilityMode {
 func (ctx *Ctx) BuildExecuteParams(command string, eventData []string) (shell string, cmd []string, env []string) {
 	environments := ctx.envReshape()
 	shell = ctx.getShell()
-	shellArgs := strings.Split(ctx.getShellArg(), ":")
+	shellArgs := utils.EscapedSplit(ctx.getShellArg(), ':')
 	shellArgs = append(shellArgs, command)
 	switch ctx.getShellArgCompatibility() {
 	case config.ArgumentPassing:

--- a/core/cmd_connection/cmd_utils/cmd_context.go
+++ b/core/cmd_connection/cmd_utils/cmd_context.go
@@ -1,0 +1,127 @@
+// Package cmdutils contain helper methods for cmd executors
+package cmdutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/FMotalleb/crontab-go/config"
+	"github.com/FMotalleb/crontab-go/ctxutils"
+)
+
+type Ctx struct {
+	context.Context
+	logger *logrus.Entry
+}
+
+func NewCtx(
+	ctx context.Context,
+	taskEnviron map[string]string,
+	logger *logrus.Entry,
+) *Ctx {
+	result := &Ctx{
+		Context: ctx,
+	}
+	result.init(taskEnviron)
+	return result
+}
+
+func (ctx *Ctx) init(taskEnviron map[string]string) {
+	osEnviron := os.Environ()
+	ctx.logger.Trace("Initial environment variables: ", osEnviron)
+	ctx.Context = context.WithValue(
+		ctx,
+		ctxutils.Environments,
+		map[string]string{},
+	)
+	for _, pair := range osEnviron {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			ctx.envAdd(parts[0], parts[1])
+		}
+	}
+	for key, val := range taskEnviron {
+		ctx.envAdd(key, val)
+		switch strings.ToLower(key) {
+		case "shell":
+			ctx.logger.Info("you've used `SHELL` env variable in command environments, overriding the global shell with:", val)
+		case "shell_args":
+			ctx.logger.Info("you've used `SHELL_ARGS` env variable in command environments, overriding the global shell_args with: ", val)
+		case "shell_arg_compatibility":
+			ctx.logger.Info("you've used `SHELL_ARG_COMPATIBILITY` env variable in command environments, overriding the global shell_arg_compatibility with: ", val)
+		}
+	}
+}
+
+func (ctx *Ctx) envGetAll() map[string]string {
+	if env := ctx.Value(ctxutils.Environments); env != nil {
+		return env.(map[string]string)
+	}
+	return map[string]string{}
+}
+
+func (ctx *Ctx) envGet(key string) string {
+	return ctx.envGetAll()[key]
+}
+
+func (ctx *Ctx) envAdd(key string, value string) {
+	oldEnv := ctx.envGetAll()
+	key = strings.ToUpper(key)
+	oldEnv[key] = value
+	ctx.Context = context.WithValue(
+		ctx,
+		ctxutils.Environments,
+		oldEnv,
+	)
+}
+
+func (ctx *Ctx) envReshape() []string {
+	env := ctx.envGetAll()
+	var result []string
+	for key, val := range env {
+		result = append(result, fmt.Sprintf("%s=%s", strings.ToUpper(key), val))
+	}
+	return result
+}
+
+func (ctx *Ctx) getShell() string {
+	return ctx.envGet("SHELL")
+}
+
+func (ctx *Ctx) getShellArg() string {
+	return ctx.envGet("SHELL_ARGS")
+}
+
+func (ctx *Ctx) getShellArgCompatibility() config.ShellArgCompatibilityMode {
+	result := config.ShellArgCompatibilityMode(ctx.envGet("SHELL_ARG_COMPATIBILITY"))
+	switch result {
+	case "":
+		return config.DefaultShellArgCompatibility
+	default:
+		return result
+	}
+}
+
+func (ctx *Ctx) BuildExecuteParams(command string, eventData []string) (shell string, cmd []string, env []string) {
+	environments := ctx.envReshape()
+	shell = ctx.getShell()
+	shellArgs := strings.Split(ctx.getShellArg(), ":")
+	shellArgs = append(shellArgs, command)
+	switch ctx.getShellArgCompatibility() {
+	case config.ArgumentPassing:
+		shellArgs = append(shellArgs, eventData...)
+	case config.EnvironmentPassing:
+		environments = append(
+			environments,
+			fmt.Sprintf("CRONTAB_GO_EVENT_ARGUMENTS=%s",
+				strings.Join(eventData, " "),
+			),
+		)
+	default:
+	}
+	return shell, shellArgs, environments
+}

--- a/core/cmd_connection/cmd_utils/cmd_context.go
+++ b/core/cmd_connection/cmd_utils/cmd_context.go
@@ -122,11 +122,23 @@ func (ctx *Ctx) BuildExecuteParams(command string, eventData []string) (shell st
 		environments = append(
 			environments,
 			fmt.Sprintf("CRONTAB_GO_EVENT_ARGUMENTS=%s",
-				strings.Join(eventData, " "),
+				collectEventForEnv(eventData),
 			),
 		)
 	default:
 		ctx.logger.Warn("event argument passing mode is not supported, using default mode (omitting)")
 	}
 	return shell, shellArgs, environments
+}
+
+func collectEventForEnv(eventData []string) string {
+	builder := &strings.Builder{}
+	for i, part := range eventData {
+		builder.WriteString(strings.ReplaceAll(part, ":", "\\:"))
+		if i < len(eventData)-1 {
+			builder.WriteRune(':')
+		}
+	}
+
+	return builder.String()
 }

--- a/core/cmd_connection/cmd_utils/cmd_context.go
+++ b/core/cmd_connection/cmd_utils/cmd_context.go
@@ -114,9 +114,11 @@ func (ctx *Ctx) BuildExecuteParams(command string, eventData []string) (shell st
 	shellArgs := utils.EscapedSplit(ctx.getShellArg(), ':')
 	shellArgs = append(shellArgs, command)
 	switch ctx.getShellArgCompatibility() {
-	case config.ArgumentPassing:
+	case config.EventArgOmit:
+		ctx.logger.Debug("event arguments will not be passed to the command")
+	case config.EventArgPassingAsArgs:
 		shellArgs = append(shellArgs, eventData...)
-	case config.EnvironmentPassing:
+	case config.EventArgPassingAsEnviron:
 		environments = append(
 			environments,
 			fmt.Sprintf("CRONTAB_GO_EVENT_ARGUMENTS=%s",
@@ -124,6 +126,7 @@ func (ctx *Ctx) BuildExecuteParams(command string, eventData []string) (shell st
 			),
 		)
 	default:
+		ctx.logger.Warn("event argument passing mode is not supported, using default mode (omitting)")
 	}
 	return shell, shellArgs, environments
 }

--- a/core/cmd_connection/cmd_utils/cmd_context.go
+++ b/core/cmd_connection/cmd_utils/cmd_context.go
@@ -25,6 +25,7 @@ func NewCtx(
 ) *Ctx {
 	result := &Ctx{
 		Context: ctx,
+		logger:  logger,
 	}
 	result.init(taskEnviron)
 	return result

--- a/core/cmd_connection/docker_create.go
+++ b/core/cmd_connection/docker_create.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/FMotalleb/crontab-go/abstraction"
 	"github.com/FMotalleb/crontab-go/config"
+	cmdutils "github.com/FMotalleb/crontab-go/core/cmd_connection/cmd_utils"
 	"github.com/FMotalleb/crontab-go/ctxutils"
 	"github.com/FMotalleb/crontab-go/helpers"
 )
@@ -53,7 +54,7 @@ func NewDockerCreateConnection(log *logrus.Entry, conn *config.TaskConnection) a
 // Returns:
 // - An error if the preparation fails, otherwise nil.
 func (d *DockerCreateConnection) Prepare(ctx context.Context, task *config.Task) error {
-	shell, shellArgs, env := reshapeEnviron(task.Env, d.log)
+	cmdCtx := cmdutils.NewCtx(ctx, task.Env, d.log)
 	d.ctx = ctx
 	if d.conn.DockerConnection == "" {
 		d.log.Debug("No explicit docker connection specified, using default: `unix:///var/run/docker.sock`")
@@ -61,15 +62,10 @@ func (d *DockerCreateConnection) Prepare(ctx context.Context, task *config.Task)
 	}
 
 	params := ctx.Value(ctxutils.EventData).([]string)
+	shell, shellArgs, environments := cmdCtx.BuildExecuteParams(task.Command, params)
 	cmd := append(
 		[]string{shell},
-		append(
-			shellArgs,
-			append(
-				[]string{task.Command},
-				params...,
-			)...,
-		)...,
+		shellArgs...,
 	)
 	volumes := make(map[string]struct{})
 	for _, volume := range d.conn.Volumes {
@@ -80,7 +76,7 @@ func (d *DockerCreateConnection) Prepare(ctx context.Context, task *config.Task)
 	d.containerConfig = &container.Config{
 		AttachStdout: true,
 		AttachStderr: true,
-		Env:          env,
+		Env:          environments,
 		WorkingDir:   task.WorkingDirectory,
 		User:         task.UserName,
 		Cmd:          cmd,

--- a/core/cmd_connection/docker_create.go
+++ b/core/cmd_connection/docker_create.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -14,6 +13,7 @@ import (
 	"github.com/FMotalleb/crontab-go/abstraction"
 	"github.com/FMotalleb/crontab-go/config"
 	cmdutils "github.com/FMotalleb/crontab-go/core/cmd_connection/cmd_utils"
+	"github.com/FMotalleb/crontab-go/core/utils"
 	"github.com/FMotalleb/crontab-go/ctxutils"
 	"github.com/FMotalleb/crontab-go/helpers"
 )
@@ -69,7 +69,7 @@ func (d *DockerCreateConnection) Prepare(ctx context.Context, task *config.Task)
 	)
 	volumes := make(map[string]struct{})
 	for _, volume := range d.conn.Volumes {
-		inContainer := strings.Split(volume, ":")[1]
+		inContainer := utils.EscapedSplit(volume, ':')[1]
 		volumes[inContainer] = struct{}{}
 	}
 	// Create an exec configuration

--- a/core/cmd_connection/helpers.go
+++ b/core/cmd_connection/helpers.go
@@ -1,15 +1,5 @@
 package connection
 
-import (
-	"fmt"
-	"os"
-	"strings"
-
-	"github.com/sirupsen/logrus"
-
-	"github.com/FMotalleb/crontab-go/cmd"
-)
-
 // reshapeEnviron modifies the environment variables for a given task.
 // It allows overriding the global shell and shell arguments with task-specific values.
 //
@@ -21,24 +11,28 @@ import (
 //   - string: The shell to be used for the task, either the global shell or the overridden shell.
 //   - []string: The shell arguments to be used for the task, either the global shell arguments or the overridden shell arguments.
 //   - []string: The complete set of environment variables for the task, including any task-specific overrides.
-func reshapeEnviron(taskEnvironments map[string]string, log *logrus.Entry) (string, []string, []string) {
-	shell := cmd.CFG.Shell
-	shellArgs := strings.Split(cmd.CFG.ShellArgs[0], ":")
-	env := os.Environ()
-	log.Trace("Initial environment variables: ", env)
-	for key, val := range taskEnvironments {
-		env = append(env, fmt.Sprintf("%s=%s", strings.ToUpper(key), val))
-		oldValue := os.Getenv(key)
-		log.Debugf("Adding environment variable: %s=%s, before this change was: `%s`", key, val, oldValue)
-		switch strings.ToLower(key) {
-		case "shell":
-			log.Info("you've used `SHELL` env variable in command environments, overriding the global shell with:", val)
-			shell = val
-		case "shell_args":
-			log.Info("you've used `SHELL_ARGS` env variable in command environments, overriding the global shell_args with: ", val)
-			shellArgs = strings.Split(val, ":")
-		}
-	}
-	log.Trace("Final environment variables: ", env)
-	return shell, shellArgs, env
-}
+// func reshapeEnviron(ctx CmdCtx, taskEnvironments map[string]string, log *logrus.Entry) (string, []string, []string) {
+// 	shell := cmd.CFG.Shell
+// 	shellArgs := strings.Split(cmd.CFG.ShellArgs[0], ":")
+// 	env := os.Environ()
+// 	log.Trace("Initial environment variables: ", env)
+// 	for key, val := range taskEnvironments {
+// 		env = append(env, fmt.Sprintf("%s=%s", strings.ToUpper(key), val))
+// 		oldValue := os.Getenv(key)
+// 		log.Tracef("Adding environment variable: %s=%s, before this change was: `%s`", key, val, oldValue)
+// 		switch strings.ToLower(key) {
+// 		case "shell":
+// 			log.Info("you've used `SHELL` env variable in command environments, overriding the global shell with:", val)
+// 			shell = val
+// 		case "shell_args":
+// 			log.Info("you've used `SHELL_ARGS` env variable in command environments, overriding the global shell_args with: ", val)
+// 			shellArgs = strings.Split(val, ":")
+// 		case "shell_arg_compatibility":
+// 			log.Info("you've used `SHELL_ARG_COMPATIBILITY` env variable in command environments, overriding the global shell_arg_compatibility with: ", val)
+// 			env = append(env, fmt.Sprintf("%s=%s", "CRONTAB_GO_EVENT_ARGUMENTS", val))
+// 			shellArgCompatibility = strings.Split(val, ":")
+// 		}
+// 	}
+// 	log.Trace("Final environment variables: ", env)
+// 	return shell, shellArgs, env
+// }

--- a/core/os_credential/windows_credential.go
+++ b/core/os_credential/windows_credential.go
@@ -10,11 +10,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// NOOP if user and group are empty log a warning if not and always returns nil
 func Validate(log *logrus.Entry, usr string, grp string) error {
+	if usr == "" && grp == "" {
+		return nil // skip warn message if no user and group provided
+	}
 	log.Warn("windows os does not have capability to set user thus validation will pass but will not work")
 	return nil
 }
 
+// NOOP
 func SetUser(log *logrus.Entry, _ *exec.Cmd, _ string, _ string) {
-	log.Warn("cannot set user in windows platform")
 }

--- a/core/os_credential/windows_credential.go
+++ b/core/os_credential/windows_credential.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NOOP if user and group are empty log a warning if not and always returns nil
+// Validate NOOP if user and group are empty log a warning if not and always returns nil
 func Validate(log *logrus.Entry, usr string, grp string) error {
 	if usr == "" && grp == "" {
 		return nil // skip warn message if no user and group provided
@@ -19,6 +19,6 @@ func Validate(log *logrus.Entry, usr string, grp string) error {
 	return nil
 }
 
-// NOOP
+// SetUser NOOP
 func SetUser(log *logrus.Entry, _ *exec.Cmd, _ string, _ string) {
 }

--- a/core/utils/strings.go
+++ b/core/utils/strings.go
@@ -1,0 +1,40 @@
+package utils
+
+const (
+	escapedCharacter = '\\'
+)
+
+func EscapedSplit(s string, sep rune) []string {
+	result := make([]string, 0)
+	buffer := make([]byte, 0)
+	pushBuff := func(r rune) {
+		buffer = append(buffer, byte(r))
+	}
+	escaped := false
+
+	for _, part := range s {
+		switch {
+		case escaped && part == sep:
+			pushBuff(part)
+			escaped = false
+		case escaped && part != sep:
+			pushBuff(escapedCharacter)
+			pushBuff(part)
+			escaped = false
+		case part == escapedCharacter:
+			escaped = true
+		case part == sep:
+			result = append(result, string(buffer))
+			buffer = make([]byte, 0)
+		default:
+			pushBuff(part)
+		}
+	}
+	if len(buffer) > 0 {
+		result = append(result, string(buffer))
+	}
+	if escaped {
+		panic("escaped character at the end of string")
+	}
+	return result
+}

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -162,3 +162,45 @@ func TestList(t *testing.T) {
 		assert.True(t, list.IsNotEmpty())
 	})
 }
+
+func TestEscapedSplit(t *testing.T) {
+	t.Run("Panic when last rune is escape rune '\\'",
+		func(t *testing.T) {
+			str := "must-panic\\"
+			assert.Panics(t, func() {
+				utils.EscapedSplit(str, '-')
+			})
+		},
+	)
+	t.Run("Normal input returns slice with single item (whole input)",
+		func(t *testing.T) {
+			str := "nothing to split"
+			result := utils.EscapedSplit(str, '-')
+			assert.Equal(t, []string{str}, result)
+		},
+	)
+	t.Run("Normal input (with escaped splitter) returns slice with single item (whole input)",
+		func(t *testing.T) {
+			str := "does\\ not\\ split"
+			expectedResult := []string{"does not split"}
+			result := utils.EscapedSplit(str, ' ')
+			assert.Equal(t, expectedResult, result)
+		},
+	)
+	t.Run("Normal escape does nothing to non split character",
+		func(t *testing.T) {
+			str := "does\\nnot\\nsplit"
+			expectedResult := []string{"does\\nnot\\nsplit"}
+			result := utils.EscapedSplit(str, ' ')
+			assert.Equal(t, expectedResult, result)
+		},
+	)
+	t.Run("Normal input with and without escaped splitter returns correct slice",
+		func(t *testing.T) {
+			str := "this splits but this\\ will\\ not"
+			expectedResult := []string{"this", "splits", "but", "this will not"}
+			result := utils.EscapedSplit(str, ' ')
+			assert.Equal(t, expectedResult, result)
+		},
+	)
+}

--- a/ctxutils/keys.go
+++ b/ctxutils/keys.go
@@ -12,4 +12,5 @@ var (
 	FailedRemotes  ContextKey = ContextKey("failed-remotes")
 	EventListeners ContextKey = ContextKey("event-listeners")
 	EventData      ContextKey = ContextKey("event-data")
+	Environments   ContextKey = ContextKey("cmd-environments")
 )


### PR DESCRIPTION
feat: event arg mode
* Supporting modes: none, arg, env
  * none: nothing will be done ignoring event arguments
  * arg: passing event arguments as additional arguments to the command
  * env: environment variable `CRONTAB_GO_EVENT_ARGUMENTS` will be set (separator: `:`)
fix: splitter caused an issue on windows (`C:/` with `:` separator would be like `C /`)
* now this issue is fixed using escape char (`\`) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable `SHELL_ARG_COMPATIBILITY` for enhanced configurability.
	- Added a new utility function `EscapedSplit` for improved string manipulation.

- **Bug Fixes**
	- Modified error handling in user setting functions to prevent unnecessary logging on Windows.

- **Documentation**
	- Enhanced comments in the `.env.example` file for better clarity on environment variable usage.

- **Refactor**
	- Streamlined command preparation processes across various components by utilizing a new context management approach.

- **Tests**
	- Added comprehensive test cases for the `EscapedSplit` function to ensure correct behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->